### PR TITLE
Add Random Trader Generation Based on Difficulty

### DIFF
--- a/wss/game.py
+++ b/wss/game.py
@@ -34,7 +34,7 @@ class Game:
 
         map_size = self.difficulty_presets[difficulty]["map_size"]
         item_count = self.difficulty_presets[difficulty]["item_count"]
-        self.map = Map(map_size[0], map_size[1], item_count)
+        self.map = Map(map_size[0], map_size[1], item_count, difficulty)
 
         self.dead_players: list[Player] = []
         self.players: list[Player] = []


### PR DESCRIPTION
Added DIFFICULTY_TRADERS dictionary to scale trader count based on difficulty:
- Easy -> 3 Traders
- Medium -> 5 Traders
- Hard -> 8 Traders

Implemented populate_traders() in Map to randomly generate traders on valid map tiles.
- Updated Map constructor to call populate_traders() during initialization.
- Updated Game to pass difficulty to Map.